### PR TITLE
Add failing test case for unions

### DIFF
--- a/tests/Type/PslTypeSpecifyingExtensionTest.php
+++ b/tests/Type/PslTypeSpecifyingExtensionTest.php
@@ -17,6 +17,7 @@ class PslTypeSpecifyingExtensionTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/coerce.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/assert.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/matches.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9.php');
 		if (InstalledVersions::satisfies(new VersionParser(), 'azjezz/psl', '<2.0.0')) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/complexTypev1.php');
 		} else {

--- a/tests/Type/data/bug-9.php
+++ b/tests/Type/data/bug-9.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PslBug9Test;
+
+use Psl\Type;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param mixed $input
+ */
+function checkShape($input): void
+{
+	$output = Type\shape([
+		'foo' => Type\non_empty_string(),
+		'bar' => Type\nullable(Type\non_empty_string()),
+		'baz' => Type\optional(Type\non_empty_string()),
+		'other' => Type\union(Type\non_empty_string(), Type\positive_int())
+	])->coerce($input);
+
+	assertType('array{foo: non-empty-string, bar: non-empty-string|null, baz?: non-empty-string, other: int<1, max>|non-empty_string}', $output);
+}
+
+
+/**
+ * @param mixed $input
+ */
+function checkNoShape($input): void
+{
+	$output = Type\union(Type\non_empty_string(), Type\positive_int())->coerce($input);
+
+	assertType('int<1, max>|non-empty-string', $output);
+}
+
+/**
+ * @param mixed $input
+ */
+function checkNoUnion($input): void
+{
+	$output = Type\non_empty_string()->assert($input);
+
+	assertType('non-empty-string', $output);
+}


### PR DESCRIPTION
Seems unions for scalars with additional data (non-empty) lose their extra data

Failing test cases for: #9 