### PR TITLE
Update `azjezz/psl` version constraints in `composer.json` to support…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         "phpstan/phpstan": "^2.0"
     },
     "conflict": {
-        "azjezz/psl": "<1.6||>=4.0"
+        "azjezz/psl": "<1.6||>=5.0"
     },
     "require-dev": {
-        "azjezz/psl": "^1.6||^2.0||^3.0",
+        "azjezz/psl": "^1.6||^2.0||^3.0||^4.0",
         "composer/semver": "^3.3",
         "nikic/php-parser": "^4.14.0",
         "php-parallel-lint/php-parallel-lint": "^1.2",


### PR DESCRIPTION
Update azjezz/psl version constraints in composer.json to support `^4.0` and restrict conflicts to `<1.6||>=5.0`.

Fixes #21