### PR TITLE
More precise types after `Option::filter()`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -1,5 +1,6 @@
 parameters:
 	stubFiles:
+		- stubs/Option.stub
 		- stubs/optional.stub
 		- stubs/OptionalType.stub
 		- stubs/Type.stub
@@ -20,3 +21,8 @@ services:
 		class: Psl\PHPStan\Type\MatchesTypeSpecifyingExtension
 		tags:
 			- phpstan.typeSpecifier.methodTypeSpecifyingExtension
+
+	-
+		class: Psl\PHPStan\Option\OptionFilterReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Option/OptionFilterReturnTypeExtension.php
+++ b/src/Option/OptionFilterReturnTypeExtension.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types = 1);
+
+namespace Psl\PHPStan\Option;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\Expr\TypeExpr;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\Type;
+
+class OptionFilterReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		/** @var class-string */
+		return 'Psl\Option\Option'; // @phpstan-ignore varTag.nativeType
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'filter';
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+	{
+		$args = $methodCall->getArgs();
+		if (!isset($args[0])) {
+			return null;
+		}
+		$filterCallback = $args[0]->value;
+
+		$optionType = $scope->getType($methodCall->var);
+		$originalType = $optionType->getTemplateType('Psl\Option\Option', 'T'); // @phpstan-ignore argument.type
+
+		$refinedType = $this->analyzeFilterCallback($filterCallback, $originalType, $scope);
+
+		return new GenericObjectType(
+			'Psl\Option\Option',
+			[$refinedType]
+		);
+	}
+
+	private function analyzeFilterCallback(Expr $filterCallback, Type $originalType, Scope $scope): Type
+	{
+		$arrayType = new ArrayType(new IntegerType(), $originalType);
+
+		$refinedType = $scope
+			->getType(
+				new FuncCall(
+					new Name('array_filter'),
+					[new Arg(new TypeExpr($arrayType)), new Arg($filterCallback)]
+				)
+			)
+			->getIterableValueType();
+
+		if (!$refinedType->equals($originalType)) {
+			return $refinedType;
+		}
+
+		return $originalType;
+	}
+
+}

--- a/stubs/Option.stub
+++ b/stubs/Option.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace Psl\Option;
+
+use Closure;
+use Psl\Comparison;
+use Psl\Type;
+
+/**
+ * @template T
+ *
+ * @readonly
+ */
+final class Option
+{
+}

--- a/tests/Option/PslTypeSpecifyingExtensionTest.php
+++ b/tests/Option/PslTypeSpecifyingExtensionTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace Psl\PHPStan\Option;
+
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Runner\PhptTestCase;
+
+class PslTypeSpecifyingExtensionTest extends TypeInferenceTestCase
+{
+
+	/**
+	 * @return iterable<mixed>
+	 */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		if (!InstalledVersions::satisfies(new VersionParser(), 'azjezz/psl', '>=2.0.0')) {
+			Assert::markTestSkipped(sprintf('Option component is not available in current azjezz/psl installed version'));
+		}
+
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	/***
+	 * @return string[]
+	 */
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [__DIR__ . '/../../extension.neon'];
+	}
+
+}

--- a/tests/Option/data/filter.php
+++ b/tests/Option/data/filter.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PslOptionTest;
+
+use Closure;
+use Psl\Option;
+
+use function PHPStan\Testing\assertType;
+
+
+function positive_int(int $value): void
+{
+	$option = Option\some($value);
+	$option = $option->filter(fn($value) => $value > 0);
+	assertType('Psl\Option\Option<int<1, max>>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(Closure::fromCallable([\Psl\Type\positive_int(), 'matches']));
+	assertType('Psl\Option\Option<int<1, max>>', $option);
+}
+
+function non_empty_string(string $value): void
+{
+	$option = Option\some($value);
+	$option = $option->filter(fn($value) => '' !== $value);
+	assertType('Psl\Option\Option<non-empty-string>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(Closure::fromCallable([\Psl\Type\non_empty_string(), 'matches']));
+	assertType('Psl\Option\Option<non-empty-string>', $option);
+}
+
+
+function numeric_string(string $value): void
+{
+	$option = Option\some($value);
+	$option = $option->filter(fn($value) => is_numeric($value));
+	assertType('Psl\Option\Option<numeric-string>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(is_numeric(...));
+	assertType('Psl\Option\Option<numeric-string>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(Closure::fromCallable([\Psl\Type\numeric_string(), 'matches']));
+	assertType('Psl\Option\Option<numeric-string>', $option);
+}
+
+function literal_string(string $value): void
+{
+	$option = Option\some($value);
+	$option = $option->filter(fn($value) => 'potato' === $value);
+	assertType('Psl\Option\Option<\'potato\'>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(fn ($value) => 'potato' === $value || 'tomato' === $value);
+	assertType('Psl\Option\Option<\'potato\'|\'tomato\'>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(fn ($value) => in_array($value, ['potato', 'tomato'], true));
+	assertType('Psl\Option\Option<\'potato\'|\'tomato\'>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(Closure::fromCallable([\Psl\Type\literal_scalar('potato'), 'matches']));
+	assertType('Psl\Option\Option<\'potato\'>', $option);
+}
+
+
+/**
+ * @param list<float> $value
+ */
+function filter_list(array $value): void
+{
+	$option = Option\some($value);
+	assertType('Psl\Option\Option<list<float>>', $option);
+	$option = $option->filter(fn($value) => [] !== $value);
+	assertType('Psl\Option\Option<non-empty-list<float>>', $option);
+
+	$option = Option\some($value);
+	assertType('Psl\Option\Option<list<float>>', $option);
+	$option = $option->filter(Closure::fromCallable([\Psl\Type\non_empty_vec(), 'matches']));
+	assertType('Psl\Option\Option<non-empty-list<float>>', $option);
+}
+


### PR DESCRIPTION
I've been digging into trying to refine the type inside of `Option<T>` as I made a heavy use of it. Right now I'm writing a lot of code that looks like this:

```php
$data
    ->filter(non_empty_string()->matches(...))
    ->map(non_empty_string()->assert(...))
```

that I think could be easily avoided.

As I've been able to write a handful of Rector rules, I decided to try to make an implementation, but I have to confess that I _✨vibed✨_ it a little bit. I'm trying to fully understand each step, but some details are escaping my current knowledge.

Right now it seems to work, except for cases like `\Psl\Type\non_empty_list()->matches(...)`. I think that there should be a generic way of handling those and not hardcoding the `TypeInterface`, but I'm not getting it to work.

Do you think it could be a nice-to-have feature, and how it's done? I will happily receive any kind of feedback so I can become less dependent on LLMs to write PHPStan rules. I also would love to implement this feature on `VectorInterface`, `MapInterface`, etc.