### PR TITLE
More precise types after `Option::filter()`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ cs:
 
 .PHONY: cs-fix
 cs-fix:
-	vendor/bin/phpcbf
+	build-cs/vendor/bin/phpcbf
 
 .PHONY: phpstan
 phpstan:

--- a/extension.neon
+++ b/extension.neon
@@ -1,5 +1,6 @@
 parameters:
 	stubFiles:
+		- stubs/Option.stub
 		- stubs/optional.stub
 		- stubs/OptionalType.stub
 		- stubs/Type.stub
@@ -20,3 +21,8 @@ services:
 		class: Psl\PHPStan\Type\MatchesTypeSpecifyingExtension
 		tags:
 			- phpstan.typeSpecifier.methodTypeSpecifyingExtension
+
+	-
+		class: Psl\PHPStan\Option\OptionFilterReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/phpstan-baseline-psl-1.neon
+++ b/phpstan-baseline-psl-1.neon
@@ -1,0 +1,13 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Class Psl\\Option\\Option not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Option/OptionFilterReturnTypeExtension.php
+
+		-
+			message: '#^Parameter \#1 \$ancestorClassName of method PHPStan\\Type\\Type\:\:getTemplateType\(\) expects class\-string, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Option/OptionFilterReturnTypeExtension.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
 	- extension.neon
+	- phpstan-baseline-psl-1.neon
 	- vendor/phpstan/phpstan-phpunit/extension.neon
 	- vendor/phpstan/phpstan-phpunit/rules.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
@@ -8,3 +9,19 @@ includes:
 parameters:
 	excludePaths:
 		- tests/*/data/*
+
+	reportUnmatchedIgnoredErrors: false
+
+	ignoreErrors:
+		-
+			message: '~^Parameter #1 \$assertType of method Psl\\PHPStan\\Option\\PslTypeSpecifyingExtensionTest::testFileAsserts\(\) expects string, mixed given\.~'
+			path: tests/Option/PslTypeSpecifyingExtensionTest.php
+		-
+			message: '~^Parameter #2 \$file of method Psl\\PHPStan\\Option\\PslTypeSpecifyingExtensionTest::testFileAsserts\(\) expects string, mixed given\.~'
+			path: tests/Option/PslTypeSpecifyingExtensionTest.php
+		-
+			message: '~^Parameter #1 \$assertType of method Psl\\PHPStan\\Type\\PslTypeSpecifyingExtensionTest::testFileAsserts\(\) expects string, mixed given\.~'
+			path:  tests/Type/PslTypeSpecifyingExtensionTest.php
+		-
+			message: '~^Parameter #2 \$file of method Psl\\PHPStan\\Type\\PslTypeSpecifyingExtensionTest::testFileAsserts\(\) expects string, mixed given\.~'
+			path:  tests/Type/PslTypeSpecifyingExtensionTest.php

--- a/src/Option/OptionFilterReturnTypeExtension.php
+++ b/src/Option/OptionFilterReturnTypeExtension.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types = 1);
+
+namespace Psl\PHPStan\Option;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\Expr\TypeExpr;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\Type;
+use Psl\Option\Option;
+
+class OptionFilterReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return Option::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'filter';
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+	{
+		$args = $methodCall->getArgs();
+		if (!isset($args[0])) {
+			return null;
+		}
+		$filterCallback = $args[0]->value;
+
+		$optionType = $scope->getType($methodCall->var);
+		$originalType = $optionType->getTemplateType('Psl\Option\Option', 'T');
+
+		$refinedType = $this->analyzeFilterCallback($filterCallback, $originalType, $scope);
+
+		return new GenericObjectType(
+			'Psl\Option\Option',
+			[$refinedType]
+		);
+	}
+
+	private function analyzeFilterCallback(Expr $filterCallback, Type $originalType, Scope $scope): Type
+	{
+		$arrayType = new ArrayType(new IntegerType(), $originalType);
+
+		$refinedType = $scope
+			->getType(
+				new FuncCall(
+					new Name('array_filter'),
+					[new Arg(new TypeExpr($arrayType)), new Arg($filterCallback)]
+				)
+			)
+			->getIterableValueType();
+
+		if (!$refinedType->equals($originalType)) {
+			return $refinedType;
+		}
+
+		return $originalType;
+	}
+
+}

--- a/stubs/Option.stub
+++ b/stubs/Option.stub
@@ -1,0 +1,31 @@
+<?php
+
+namespace Psl\Option;
+
+use Closure;
+use Psl\Comparison;
+use Psl\Type;
+
+/**
+ * @template T
+ *
+ * @readonly
+ */
+final class Option
+{
+
+    /**
+     * Returns none if the option is none, otherwise calls `$predicate` with the wrapped value and returns:
+     *  - Option<T>::some() if `$predicate` returns true (where t is the wrapped value), and
+     *  - Option<T>::none() if `$predicate` returns false.
+     *
+     * @param (Closure(T): bool) $predicate
+     *
+     * @param-immediately-invoked-callable $predicate
+     *
+     * @return Option<T>
+     */
+    public function filter(Closure $predicate): Option
+    {
+    }
+}

--- a/tests/Option/PslTypeSpecifyingExtensionTest.php
+++ b/tests/Option/PslTypeSpecifyingExtensionTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace Psl\PHPStan\Option;
+
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Assert;
+use function sprintf;
+
+class PslTypeSpecifyingExtensionTest extends TypeInferenceTestCase
+{
+
+	/**
+	 * @return iterable<mixed>
+	 */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		if (!InstalledVersions::satisfies(new VersionParser(), 'azjezz/psl', '>=2.2.0')) {
+			Assert::markTestSkipped(sprintf('Option component is not available in current azjezz/psl installed version'));
+		}
+
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	/***
+	 * @return string[]
+	 */
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [__DIR__ . '/../../extension.neon'];
+	}
+
+}

--- a/tests/Option/data/filter.php
+++ b/tests/Option/data/filter.php
@@ -1,0 +1,122 @@
+<?php // lint >= 8.1
+
+declare(strict_types=1);
+
+namespace PslOptionTest;
+
+use Closure;
+use Psl\Option;
+use Psl\Type;
+
+use function PHPStan\Testing\assertType;
+
+
+function positive_int(int $value): void
+{
+	$option = Option\some($value);
+	$option = $option->filter(fn($value) => $value > 0);
+	assertType('Psl\Option\Option<int<1, max>>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(Type\positive_int()->matches(...));
+	assertType('Psl\Option\Option<int<1, max>>', $option);
+
+	assertType(
+		'Psl\Option\Option<*NEVER*>',
+		$option->filter(Type\literal_scalar(0)->matches(...))
+	);
+}
+
+function non_empty_string(string $value): void
+{
+	$option = Option\some($value);
+	$option = $option->filter(fn($value) => '' !== $value);
+	assertType('Psl\Option\Option<non-empty-string>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(Type\non_empty_string()->matches(...));
+	assertType('Psl\Option\Option<non-empty-string>', $option);
+
+	assertType(
+		'Psl\Option\Option<non-empty-string>',
+		$option->filter(Type\string()->matches(...))
+	);
+
+	assertType(
+		'Psl\Option\Option<*NEVER*>',
+		$option->filter(Type\literal_scalar('')->matches(...))
+	);
+}
+
+
+function numeric_string(string $value): void
+{
+	$option = Option\some($value);
+	$option = $option->filter(fn($value) => is_numeric($value));
+	assertType('Psl\Option\Option<numeric-string>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(is_numeric(...));
+	assertType('Psl\Option\Option<numeric-string>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(Type\numeric_string()->matches(...));
+	assertType('Psl\Option\Option<numeric-string>', $option);
+
+	assertType(
+		'Psl\Option\Option<*NEVER*>',
+		$option->filter(Type\int()->matches(...))
+	);
+}
+
+function literal_string(string $value): void
+{
+	$option = Option\some($value);
+	$option = $option->filter(fn($value) => 'potato' === $value);
+	assertType('Psl\Option\Option<\'potato\'>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(fn ($value) => 'potato' === $value || 'tomato' === $value);
+	assertType('Psl\Option\Option<\'potato\'|\'tomato\'>', $option);
+
+	$option = Option\some($value);
+	$option = $option->filter(fn ($value) => in_array($value, ['potato', 'tomato'], true));
+	assertType('Psl\Option\Option<\'potato\'|\'tomato\'>', $option);
+
+	assertType(
+		'Psl\Option\Option<*NEVER*>',
+		$option->filter(Type\int()->matches(...))
+	);
+
+	assertType(
+		'Psl\Option\Option<\'potato\'>',
+		$option->filter(Type\literal_scalar('potato')->matches(...))
+	);
+
+	assertType(
+		'Psl\Option\Option<\'potato\'|\'tomato\'>',
+		$option->filter(Type\string()->matches(...))
+	);
+
+	$option = Option\some($value);
+	$option = $option->filter(Type\literal_scalar('potato')->matches(...));
+	assertType('Psl\Option\Option<\'potato\'>', $option);
+}
+
+
+/**
+ * @param list<float> $value
+ */
+function filter_list(array $value): void
+{
+	$option = Option\some($value);
+	assertType('Psl\Option\Option<list<float>>', $option);
+	$option = $option->filter(fn($value) => [] !== $value);
+	assertType('Psl\Option\Option<non-empty-list<float>>', $option);
+
+	$option = Option\some($value);
+	assertType('Psl\Option\Option<list<float>>', $option);
+	$option = $option->filter(Type\non_empty_vec(Type\float())->matches(...));
+	assertType('Psl\Option\Option<non-empty-list<float>>', $option);
+}
+


### PR DESCRIPTION
After some lessons learned on https://github.com/php-standard-library/phpstan-extension/pull/23 and studying other PHPStan plugins, I think this PR should be good! Sorry for the noise on the previous one.

I've ignored some errors due to https://github.com/php-standard-library/phpstan-extension/issues/24, I've tried to do it in several ways before ignoring them. Please let me know if I can handle them better.
